### PR TITLE
Added a way to find out your own user id

### DIFF
--- a/scripts/id.js
+++ b/scripts/id.js
@@ -1,0 +1,12 @@
+// Description
+//   Get slack user ID
+//
+// Commands:
+//   !`id` - Shows your slack user id
+//
+//
+module.exports = function (robot) {
+    robot.respond(/!id/i, function(res) {
+        res.send(res.envelope.user.id);
+    });
+};

--- a/scripts/id.js
+++ b/scripts/id.js
@@ -6,7 +6,7 @@
 //
 //
 module.exports = function (robot) {
-    robot.respond(/!id/i, function(res) {
+    robot.respond(/!?id/i, function(res) {
         res.send(res.envelope.user.id);
     });
 };


### PR DESCRIPTION
The passthrough thing uses user IDs rather than names, if you want to use it to track yourself, you can get your own ID and identify yourself or anyone who offers you their id