### PR TITLE
Modified !exec's parsing from regex to token-based

### DIFF
--- a/scripts/exec.js
+++ b/scripts/exec.js
@@ -6,51 +6,128 @@
 //
 module.exports = function (robot) {
 	function run_cmd(res, cmd) {
+		// Allow lack of starting '!'
 		if(cmd[0] != '!') {
 			cmd = "!" + cmd;
 		}
+
 		var output = "";
+		// When the command is run, it will execute this when it calls res.send
 		var fake_send = function(str) {
 			output += str;
 		};
-		var found = false;
+
+		var found = false; // Found a command?
 		for(var i = 0; i < robot.listeners.length; i++) {
 			if(robot.listeners[i].regex == undefined) {
 				continue;
 			}
+
+			// Check the command
 			var matches = robot.listeners[i].regex.exec(cmd);
 			if(matches != null) {
 				found = true;
+				// Call the command's function with a fake `res`
 				var new_res = new robot.Response(robot, res.message, matches);
 				new_res.send = fake_send;
 				robot.listeners[i].callback(new_res);
 			}
 		}
+
 		if(!found) {
 			output = "Invalid command: '" + cmd + "'.\n";
 		} else if(output.length == 0) {
 			output = "No output.\n";
 		}
+
 		return output;
 	}
 
-	function substitute_vals(res, cmd) {
-		var matches = /!\((.+?)\)/.exec(cmd);
-		var new_cmd = cmd;
-		if(matches == null) {
-			return cmd;
+	function tokenize(cmd) {
+		var tokenized = [];
+		var cur = ""; // Current token
+		var open = 0; // # Of open brackets
+		for(var i = 0; i < cmd.length; i++) {
+			// '!('
+			if(cmd[i] == '(' && cur.length > 0 && cur[cur.length - 1] == '!') {
+				cur = cur.slice(0, cur.length - 1); // Remove the '!' from cur token
+				if(cur.length > 0) {
+					tokenized.push(cur);
+					cur = "";
+				}
+				tokenized.push("!(");
+				open++;
+			} else if(cmd[i] == ')' && open > 0) {
+				if(cur.length > 0) {
+					tokenized.push(cur);
+					cur = "";
+				}
+				tokenized.push(")");
+				open--;
+			 } else {
+				 cur += cmd[i];
+			 }
 		}
-		for(var i = 1; i < matches.length; i++) {
-			var subbed = substitute_vals(res, matches[i]);
-			var evald = run_cmd(res, subbed);
-			new_cmd = new_cmd.replace("!(" + matches[i] + ")", evald);
+
+		if(cur.length > 0) {
+			tokenized.push(cur);
 		}
-		return new_cmd;
+		return tokenized;
+	}
+
+	function substitute_vals(res, tokens) {
+		if(tokens.length == 1) {
+			return tokens[0];
+		}
+		for(var i = 0; i < tokens.length; i++) {
+			if(tokens[i] == "!(" && i < tokens.length - 1) {
+				// Possibly a command substitution, find closing bracket
+				var count = 0; // Current bracket 'level'
+				var closing = -1; // Index of closing bracket
+				for(var j = i + 1; j < tokens.length; j++) {
+					if(tokens[j] == "!(") { count++; }
+					if(tokens[j] == ")") {
+						if(count == 0) {
+							closing = j;
+							break;
+						} else {
+							count--;
+						}
+					}
+				}
+				// No closing bracket, not a valid command sub, ignore
+				if(closing == -1) {
+					continue;
+				}
+				// Recursive
+				var subbed = substitute_vals(res, tokens.slice(i + 1, j));
+				subbed = run_cmd(res, subbed); // Evaluate
+				tokens.splice(i, j - i + 1, subbed); // Substitute
+
+				// Flatten
+				if(i > 0) {
+					if(tokens[i - 1] != "!(" && tokens[i - 1] != ")") {
+						tokens[i - 1] += tokens[i];
+						tokens.splice(i, 1);
+					}
+				}
+				if(i < tokens.length - 1) {
+					if(tokens[i + 1] != ")" && tokens[i + 1] != "!(") {
+						tokens[i] += tokens[i + 1];
+						tokens.splice(i + 1, 1);
+					}
+				}
+
+				i--; // Recheck this token
+			}
+		}
+		return tokens;
 	}
 
 	robot.respond(/!?exec (.+)/i, function (res) {
 		var message = res.match[1];
-		var evald = substitute_vals(res, message);
-		res.send(evald + '\n');
+		var tokens = tokenize(message);
+		var evald = substitute_vals(res, tokens);
+		res.send(evald.join("") + '\n');
 	});
 }


### PR DESCRIPTION
- This was needed to allow for both horizontal (ie: "!(caesar
  h)!(caesar i)") and vertical (ie: "!(caesar !(caesar hi))")
