### PR TITLE
Implemented !vote, button-based alternative!

### DIFF
--- a/scripts/button_listener.js
+++ b/scripts/button_listener.js
@@ -43,7 +43,6 @@ module.exports = function (robot) {
         // Increment vote counter
         var title = attachments[0].fields[type].title;
         var count = parseInt(title[title.length - 2]) + 1;
-        robot.logger.info(count);
         
         if (type == YES_VOTE) {
             attachments[0].fields[type].title = "Yes (" + count + ")";
@@ -54,8 +53,6 @@ module.exports = function (robot) {
         else {
 
         }
-
-        robot.logger.info(attachments[0].fields[type]);
 
         // Update message
         robot.adapter.client.web.chat.update(payload.message_ts,

--- a/scripts/button_listener.js
+++ b/scripts/button_listener.js
@@ -1,0 +1,65 @@
+// Description
+//   Listens for button post requests
+//
+
+const YES_VOTE = 0;
+const NO_VOTE = 1;
+const ABSTAIN_VOTE = 2;
+
+module.exports = function (robot) {
+    robot.router.post("/button", function(req, res) {
+        var payload = JSON.parse(req.body.payload);
+        //robot.logger.info(payload);
+        // Verification token
+        if (payload.token == process.env.SLACK_VERIFICATION_TOKEN) {
+            res.end(); // Return response early to reduce timeouts
+            if (payload.callback_id == 'vote') {              
+                if (payload.actions[0].name == 'yes') {
+                    process_vote(payload, res, YES_VOTE);
+                }
+                else if (payload.actions[0].name == 'no') {
+                    process_vote(payload, res, NO_VOTE);
+                }
+                else {
+                    // Unknown action
+                }
+            }
+        }
+        else {
+            res.writeHead(403, {'Content-Type': 'text/plain'});
+            res.end();
+        }
+    });
+
+
+    function process_vote(payload, res, type) {
+        var attachments = payload.original_message.attachments;
+
+        // Add voter to appropriate field
+        var newVoteList = attachments[0].fields[type].value
+         + "\r" + payload.user.name;
+        attachments[0].fields[type].value = newVoteList;
+
+        // Increment vote counter
+        var title = attachments[0].fields[type].title;
+        var count = parseInt(title[title.length - 2]) + 1;
+        robot.logger.info(count);
+        
+        if (type == YES_VOTE) {
+            attachments[0].fields[type].title = "Yes (" + count + ")";
+        }
+        else if (type == NO_VOTE) {
+            attachments[0].fields[type].title = "No (" + count + ")";
+        }
+        else {
+
+        }
+
+        robot.logger.info(attachments[0].fields[type]);
+
+        // Update message
+        robot.adapter.client.web.chat.update(payload.message_ts,
+            payload.channel.id, payload.original_message.text,
+            {"attachments": attachments, "link_names": false});
+    }
+};

--- a/scripts/button_listener.js
+++ b/scripts/button_listener.js
@@ -15,10 +15,13 @@ module.exports = function (robot) {
             res.end(); // Return response early to reduce timeouts
             if (payload.callback_id == 'vote') {              
                 if (payload.actions[0].name == 'yes') {
-                    process_vote(payload, res, YES_VOTE);
+                    process_action(payload, res, YES_VOTE);
                 }
                 else if (payload.actions[0].name == 'no') {
-                    process_vote(payload, res, NO_VOTE);
+                    process_action(payload, res, NO_VOTE);
+                }
+                else if (payload.actions[0].name == 'abstain') {
+                    process_action(payload, res, ABSTAIN_VOTE);
                 }
                 else {
                     // Unknown action
@@ -32,31 +35,68 @@ module.exports = function (robot) {
     });
 
 
-    function process_vote(payload, res, type) {
-        var attachments = payload.original_message.attachments;
-
-        // Add voter to appropriate field
-        var newVoteList = attachments[0].fields[type].value
-         + "\r" + payload.user.name;
-        attachments[0].fields[type].value = newVoteList;
-
-        // Increment vote counter
-        var title = attachments[0].fields[type].title;
-        var count = parseInt(title[title.length - 2]) + 1;
-        
+    function process_action(payload, res, type) {
         if (type == YES_VOTE) {
-            attachments[0].fields[type].title = "Yes (" + count + ")";
+            process_vote(payload, res, type);
         }
         else if (type == NO_VOTE) {
-            attachments[0].fields[type].title = "No (" + count + ")";
+            process_vote(payload, res, type);
         }
-        else {
+        else if (type == ABSTAIN_VOTE) {
+            // Remove our user from the vote list if they're on it
+            remove_vote(payload, YES_VOTE);
+            remove_vote(payload, NO_VOTE);
+        }
 
-        }
+        // Update vote count
+        var attachments = payload.original_message.attachments;
+        attachments[0].fields[YES_VOTE].title = "Yes (" + count_votes(payload, YES_VOTE) + ")";
+        attachments[0].fields[NO_VOTE].title = "No (" + count_votes(payload, NO_VOTE) + ")";
 
         // Update message
         robot.adapter.client.web.chat.update(payload.message_ts,
             payload.channel.id, payload.original_message.text,
-            {"attachments": attachments, "link_names": false});
+            {"attachments": payload.original_message.attachments});
+    }
+
+    function process_vote(payload, res, type) {
+        var attachments = payload.original_message.attachments;
+        var voteList = attachments[0].fields[type].value;
+        var name = payload.user.name;
+        var title = attachments[0].fields[type].title;
+
+        // Check if our user has voted already
+        if (voteList.search("\n" + name) == -1) {
+            // Add voter to appropriate field
+            var newVoteList = voteList + "\n" + name;
+            attachments[0].fields[type].value = newVoteList;
+        }
+
+        // Remove vote from other list if it exists
+        if (type == YES_VOTE) {
+            remove_vote(payload, NO_VOTE);
+        }
+        else {
+            remove_vote(payload, YES_VOTE);
+        }
+    }
+
+    function remove_vote(payload, type) {
+        var attachments = payload.original_message.attachments;
+        var name = payload.user.name;
+        var voteList = attachments[0].fields[type].value;
+        attachments[0].fields[type].value = voteList.replace("\n" + name, "");
+    }
+
+    function count_votes(payload, type) {
+        // This seems like a bad way to store vote info (and count it)
+        var count = 0;
+        var list = payload.original_message.attachments[0].fields[type].value;
+        for (var i=0; i < list.length; i++) {
+            if (list[i] === '\n') {
+                count++;
+            }
+        }
+        return count;
     }
 };

--- a/scripts/button_listener.js
+++ b/scripts/button_listener.js
@@ -91,7 +91,7 @@ module.exports = function (robot) {
         // This seems like a bad way to store vote info (and count it)
         var count = 0;
         var list = payload.original_message.attachments[0].fields[type].value;
-        for (var i=0; i < list.length; i++) {
+        for (var i = 0; i < list.length; i++) {
             if (list[i] === '\n') {
                 count++;
             }

--- a/scripts/vote.js
+++ b/scripts/vote.js
@@ -1,0 +1,48 @@
+// Description
+//   Allows users to vote yes/no to a question
+//
+// Commands:
+//   !`vote` <name> - Start's a vote with the given name
+//
+
+module.exports = function (robot) {
+    robot.respond(/!?vote ?(.+)/i, function (res) {
+        robot.adapter.client.web.chat.postMessage(res.message.room,
+            res.message.user.name + ": " + res.match[1],  {
+            "attachments": [
+                {
+                    "text": "",
+                    "fallback": "Fail",
+                    "color": "#3AA3E3",
+                    "callback_id": "vote",
+                    "link_names": false,
+                    "attachment_type": "default",
+                    "fields" : [
+                        {
+                            "title": "Yes (0)",
+                            "value": "",
+                            "short": true
+                        },
+                        {
+                            "title": "No (0)",
+                            "value": "",
+                            "short": true
+                        },
+                    ],
+                    "actions": [
+                        {
+                            "name": "yes",
+                            "text": "Yes",
+                            "type": "button"
+                        },
+                        {
+                            "name": "no",
+                            "text": "No",
+                            "type": "button"
+                        },
+                    ]
+                }
+            ]}
+        );
+    });
+};

--- a/scripts/vote.js
+++ b/scripts/vote.js
@@ -6,7 +6,7 @@
 //
 
 module.exports = function (robot) {
-    robot.respond(/!?vote ?(.+)/i, function (res) {
+    robot.respond(/!?vote (.+)/i, function (res) {
         robot.adapter.client.web.chat.postMessage(res.message.room,
             res.message.user.name + ": " + res.match[1],  {
             "attachments": [
@@ -38,6 +38,11 @@ module.exports = function (robot) {
                         {
                             "name": "no",
                             "text": "No",
+                            "type": "button"
+                        },
+                        {
+                            "name": "abstain",
+                            "text": "Abstain",
                             "type": "button"
                         },
                     ]


### PR DESCRIPTION
Fancy voting buttons. ~~There's a couple obvious issues such as people voting multiple times, having no way to undo a vote and potentially annoying highlighting when someone votes. Decided to implement this separate from !voteythumbs for these reasons.~~

In order to run this another environmental variable is needed: `SLACK_VERIFICATION_TOKEN` which is just the verification token in the app (assuming the bot becomes an app). Also an interactive messages URL needs to be set. My setup just has this as <server>/vote right now but that's easy enough to change. 

Another thing to note is if uqcsbot is in app form this could probably be implemented as /vote and be cleaner.

Demo (Abstain removes existing vote):
![vote](https://cloud.githubusercontent.com/assets/7283010/24863583/c63238a6-1e44-11e7-9849-c5cadc6a2977.gif)


